### PR TITLE
fix issue with compressing js with compile errors

### DIFF
--- a/src/dieter/compressor.clj
+++ b/src/dieter/compressor.clj
@@ -13,7 +13,8 @@
     (.compile compiler (make-array JSSourceFile 0)
               (into-array JSSourceFile [(JSSourceFile/fromCode "awesome-js" text)])
               options)
-    (or (seq (.toSource compiler)) text)))
+    (let [source (.toSource compiler)]
+      (if (seq source) source text))))
 
 (defn compress-css [text]
   (-> text

--- a/test/dieter/test/core.clj
+++ b/test/dieter/test/core.clj
@@ -39,7 +39,11 @@
         (is (= "var foo=\"bar\";"
                (compress uncompressed-js "foo.js")))
         (is (= ".content .p { color: #fff; }"
-               (compress uncompressed-css "foo.css")))))))
+               (compress uncompressed-css "foo.css")))
+        (testing "with compile errors will not compress"
+          (let [uncompressed-with-errors "var foo = [1, 2, 3, ];"]
+            (is (= uncompressed-with-errors
+                 (compress uncompressed-with-errors "foo.js")))))))))
 
 (deftest test-link-to-asset
   (testing "development mode"


### PR DESCRIPTION
If the js compile fails, it will return the uncompressed js. For some reason, the compiler doesn't like our Ember code. That will require further investigation.
