### PR TITLE
Load file with same name as dir

### DIFF
--- a/src/dieter/path.clj
+++ b/src/dieter/path.clj
@@ -30,12 +30,13 @@ static file middleware can be rooted at cache-root"
     (cond
      (re-matches #".*/$" relative-path) (io/file start-dir relative-path)
      relative-parent (io/file start-dir relative-parent)
-     :else start-dir)))
+    :else start-dir)))
 
 (defn find-in-files [filename files]
   (let [[_ basename] (re-matches #"(^.*?)(?:\.\w+)?$" filename)
         pattern (re-pattern (str "^" basename ".*$"))]
-    (first (filter #(re-matches pattern (.getName %)) files))))
+    (or (first (filter #(= filename (.getName %)) files))
+        (first (filter #(re-matches pattern (.getName %)) files)))))
 
 (defn find-file [partial-path start-dir]
   (let [relative-file (io/file partial-path)

--- a/src/dieter/path.clj
+++ b/src/dieter/path.clj
@@ -30,7 +30,7 @@ static file middleware can be rooted at cache-root"
     (cond
      (re-matches #".*/$" relative-path) (io/file start-dir relative-path)
      relative-parent (io/file start-dir relative-parent)
-    :else start-dir)))
+     :else start-dir)))
 
 (defn find-in-files [filename files]
   (let [[_ basename] (re-matches #"(^.*?)(?:\.\w+)?$" filename)

--- a/test/dieter/test/manifest.clj
+++ b/test/dieter/test/manifest.clj
@@ -10,6 +10,10 @@
   (let [manifest (io/file "test/fixtures/assets/javascripts/manifest.js.dieter")
         files (manifest-files manifest)]
     (is (contains-file? files (io/file "test/fixtures/assets/javascripts/app.js")))
+    
+    (testing "load javascript file with same name as directory to be loaded"
+      (is (contains-file? files (io/file "test/fixtures/assets/javascripts/lib.js"))))
+    
     (is (contains-file? files (io/file "test/fixtures/assets/javascripts/lib/framework.js")))
     (is (contains-file? files (io/file "test/fixtures/assets/javascripts/lib/dquery.js")))
     (is (contains-file? files (io/file "test/fixtures/assets/javascripts/models/feature.js")))

--- a/test/fixtures/assets/javascripts/lib.js
+++ b/test/fixtures/assets/javascripts/lib.js
@@ -1,0 +1,1 @@
+var file = "/lib.js";

--- a/test/fixtures/assets/javascripts/manifest.js.dieter
+++ b/test/fixtures/assets/javascripts/manifest.js.dieter
@@ -2,6 +2,7 @@
   "./app.js"
   "framework.js"
   "dontfindme.js"
+  "./lib.js"
   "./lib/"
   "./models/"
 ]


### PR DESCRIPTION
I had a problem with loading files which had the same name as a directory.

MANIFEST

```
[
  "./lib.js"
  "./lib/"
]
```

The `lib.js` was not loaded via Dieter.

I have supplied a test which shows my issue along with a possible solution.
