### PR TITLE
Use fs 1.3.2; Throw coffeescript compile errors in browser

### DIFF
--- a/dieter-core/project.clj
+++ b/dieter-core/project.clj
@@ -2,7 +2,7 @@
   :description "Asset pipeline ring middleware"
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [ring "1.0.1"]
-                 [fs "0.11.1"]
+                 [fs "1.3.2"]
                  [com.google.javascript/closure-compiler "r1592"]
                  [rhino/js "1.7R2"]]
   :dev-dependencies [[org.clojure/clojure "1.3.0"]])

--- a/dieter-core/src/dieter/asset/coffeescript.clj
+++ b/dieter-core/src/dieter/asset/coffeescript.clj
@@ -2,14 +2,18 @@
   (:require
    dieter.asset
    dieter.asset.javascript
-   [dieter.pools :as pools])
+   [dieter.pools :as pools]
+   [clojure.string :as string])
   (:use [dieter.rhino :only (call with-scope)]))
 
 (def pool (pools/make-pool))
 
 (defn compile-coffeescript [input filename]
-  (with-scope pool ["coffee-script.js" "coffee-wrapper.js"]
-    (str (call "compileCoffeeScript" input filename))))
+  (try
+    (with-scope pool ["coffee-script.js" "coffee-wrapper.js"]
+      (str (call "compileCoffeeScript" input filename)))
+    (catch org.mozilla.javascript.JavaScriptException e
+      (format "throw(\"%s\")" (string/replace (.getMessage e) "\"" "\\\"" )))))
 
 (defn preprocess-coffeescript [file]
   (compile-coffeescript (slurp file) (.getCanonicalPath file)))

--- a/dieter-core/src/dieter/asset/less.clj
+++ b/dieter-core/src/dieter/asset/less.clj
@@ -5,13 +5,27 @@
    dieter.asset.css
    [dieter.pools :as pools]
    [clojure.string :as cstr]
-   [dieter.asset :as asset]))
+   [dieter.asset :as asset]
+   [clojure.string :as string]))
 
 (def pool (pools/make-pool))
 
+(defn sanitize-css-content [str]
+  (string/replace
+   (string/replace
+    str
+    "\"" "\\\"" )
+   "\n" "\\A"))
+
 (defn preprocess-less [file]
-  (with-scope pool ["less-wrapper.js" "less-rhino-1.3.0.js"]
-    (call "compileLess" (.getCanonicalPath file))))
+  (let [filename (.getCanonicalPath file)]
+    (try
+      (with-scope pool ["less-wrapper.js" "less-rhino-1.3.0.js"]
+        (call "compileLess" filename))
+      (catch org.mozilla.javascript.JavaScriptException e
+        (format "body:before { content: \"In file %s - %s\"; white-space: pre }"
+                filename
+                (sanitize-css-content (.getMessage e)))))))
 
 (defrecord Less [file]
   dieter.asset.Asset

--- a/dieter-core/src/dieter/core.clj
+++ b/dieter-core/src/dieter/core.clj
@@ -1,6 +1,6 @@
 (ns dieter.core
   (:require [clojure.java.io :as io]
-            [fs]
+            [fs.core :as fs]
             [ring.util.response :as res])
   (:use
    dieter.settings
@@ -87,15 +87,14 @@
    dir
    (fn [root _ files]
      (doseq [file files]
-       (f (->> file
-               (fs/join root)))))))
+       (f (fs/file root file))))))
 
 (defn precompile [options]
   (with-options options
-    (-> *settings* :cache-root (fs/join "assets") fs/deltree)
+    (-> *settings* :cache-root (fs/file "assets") fs/delete-dir)
     (doseq [asset-root (asset-roots)]
       (foreach-file
-       (fs/join asset-root "assets")
+       (fs/file asset-root "assets")
        (fn [filename]
          (try (->> filename
                    (relative-path asset-root)

--- a/dieter-core/src/dieter/path.clj
+++ b/dieter-core/src/dieter/path.clj
@@ -3,7 +3,7 @@
   (:require
    [clojure.string :as cstr]
    [clojure.java.io :as io]
-   [fs])
+   [fs.core :as fs])
   (:import
    [java.security MessageDigest]))
 
@@ -87,7 +87,7 @@ static file middleware can be rooted at cache-root"
       (add-md5 path (str (java.util.Date.)))))
 
 (defn relative-path [root file]
-  (let [absroot (fs/abspath root)
-        absfile (fs/abspath file)
+  (let [absroot (fs/absolute-path root)
+        absfile (fs/absolute-path file)
         root-length (count absroot)]
     (.substring absfile (inc root-length))))

--- a/dieter-core/test/dieter/test/asset/coffeescript.clj
+++ b/dieter-core/test/dieter/test/asset/coffeescript.clj
@@ -11,10 +11,10 @@
             (io/file "test/fixtures/assets/javascripts/test.js.coffee")))))
   (testing "syntax error"
     (try
-      (preprocess-coffeescript
-       (io/file "test/fixtures/assets/javascripts/bad.js.coffee"))
-      (is false) ; must throw
-      (catch Exception e
-        (is (has-text? (.toString e) "on line 2"))
-        (is (has-text? (.toString e) "bad.js.coffee"))
-        (is (has-text? (.toString e) "unmatched ]"))))))
+      (let [output (preprocess-coffeescript
+                    (io/file "test/fixtures/assets/javascripts/bad.js.coffee"))]
+
+        (is (has-text? (.toString output) "throw"))
+        (is (has-text? (.toString output) "on line 2"))
+        (is (has-text? (.toString output) "bad.js.coffee"))
+        (is (has-text? (.toString output) "unmatched ]"))))))

--- a/dieter-core/test/dieter/test/asset/less.clj
+++ b/dieter-core/test/dieter/test/asset/less.clj
@@ -11,9 +11,7 @@
     (is (= "#includee {\n  color: white;\n}\n#includee-three {\n  color: white;\n}\n#includee-two {\n  color: white;\n}\n#includer {\n  color: black;\n}\n"
            (preprocess-less (io/file "test/fixtures/assets/stylesheets/includes.less")))))
   (testing "bad less syntax"
-    (try
-      (preprocess-less (io/file "test/fixtures/assets/stylesheets/bad.less"))
-      (is false) ; test it throws
-      (catch Exception e
-        (is (has-text? (.toString e) "Syntax Error on line 1"))
-        (is (has-text? (.toString e) "@import \"includeme.less\""))))))
+    (let [output (preprocess-less (io/file "test/fixtures/assets/stylesheets/bad.less"))]
+                                        ; test it throws
+      (is (has-text? output "Syntax Error on line 1"))
+      (is (has-text? output "@import \\\"includeme.less\\\"")))))


### PR DESCRIPTION
This is a combo-pull request. Sorry about that.

The first commit upgrades dieter to use fs 1.3.2, as 0.11 was heavily outdated and, naturally, very incompatible with 1.3.2

The second commit causes CoffeeScript compile errors to surface to the browser. Rather than rendering an empty page with 500 status, it renders the compile error as a throw('<error>') script, so you immediately see javascript error in the browsers console, plus the details about which file failed to compile, which line number, and the CoffeeScript generated reason.
