### PR TITLE
Removing dependancy on fs lib

### DIFF
--- a/dieter-core/project.clj
+++ b/dieter-core/project.clj
@@ -4,11 +4,11 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :url "http://github.com/edgecase/dieter"
   :scm {:name "git" :dir ".."}
-  :dependencies [[ring "1.0.1"]
-                 [fs "0.11.1"]
+  :dependencies [[ring/ring-core "1.1.8"]
                  [clj-time "0.4.4"]
                  [com.google.javascript/closure-compiler "r1592"]
                  [clj-v8 "0.1.4"]
                  [clj-v8-native "0.1.4"]
-                 [org.mozilla/rhino "1.7R4"]]
+                 [org.mozilla/rhino "1.7R4"]
+                 [org.clojure/clojure "1.4.0"]]
   :dev-dependencies [[org.clojure/clojure "1.4.0"]])

--- a/dieter-core/src/dieter/asset.clj
+++ b/dieter-core/src/dieter/asset.clj
@@ -44,7 +44,7 @@ Contents can be a String, StringBuilder, or byte[]"))
 ;;; Register assets
 ;;;;;;;;;;;;;;;;;;;;;;;
 
-(def types 
+(def types "mapping of file types to constructor functions"
   (atom {}))
 
 (defn register [ext constructor-fn]
@@ -54,8 +54,7 @@ Contents can be a String, StringBuilder, or byte[]"))
 (defn make-asset [file]
   "returns a newly constructed asset of the proper type as determined by the file extension.
 defaults to Static if extension is not registered."
-  (
-   (get @types 
+  ((get @types 
         (file-ext file) 
         (:default @types)) 
    {:file file}))

--- a/dieter-core/src/dieter/asset.clj
+++ b/dieter-core/src/dieter/asset.clj
@@ -44,7 +44,7 @@ Contents can be a String, StringBuilder, or byte[]"))
 ;;; Register assets
 ;;;;;;;;;;;;;;;;;;;;;;;
 
-(def types "mapping of file types to constructor functions"
+(def types 
   (atom {}))
 
 (defn register [ext constructor-fn]
@@ -54,4 +54,8 @@ Contents can be a String, StringBuilder, or byte[]"))
 (defn make-asset [file]
   "returns a newly constructed asset of the proper type as determined by the file extension.
 defaults to Static if extension is not registered."
-  ((get @types (file-ext file) (:default @types)) {:file file}))
+  (
+   (get @types 
+        (file-ext file) 
+        (:default @types)) 
+   {:file file}))

--- a/dieter-core/src/dieter/core.clj
+++ b/dieter-core/src/dieter/core.clj
@@ -1,7 +1,5 @@
 (ns dieter.core
-  (:require [clojure.java.io :as io]
-            [fs]
-            [dieter.settings :as settings]
+  (:require [dieter.settings :as settings]
             [dieter.asset :as asset]
             [dieter.path :as path]
             [dieter.cache :as cache]

--- a/dieter-core/src/dieter/path.clj
+++ b/dieter-core/src/dieter/path.clj
@@ -2,8 +2,7 @@
   (:use dieter.settings)
   (:require [clojure.string :as cstr]
             [clojure.java.io :as io]
-            [dieter.settings :as settings]
-            [fs])
+            [dieter.settings :as settings])
   (:import [java.security MessageDigest]))
 
 ;;;; TODO
@@ -22,13 +21,6 @@
 
 (defn make-relative-to-cache [path]
   (cstr/replace-first path (re-pattern (str ".*" (settings/cache-root))) ""))
-
-
-(defn relative-path [root file]
-  (let [absroot (fs/abspath root)
-        absfile (fs/abspath file)
-        root-length (count absroot)]
-    (.substring absfile (inc root-length))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/dieter-core/src/dieter/precompile.clj
+++ b/dieter-core/src/dieter/precompile.clj
@@ -1,52 +1,67 @@
 (ns dieter.precompile
-  (:require [fs]
+  (:require [clojure.java.io :as io]
             [dieter.cache :as cache]
             [dieter.path :as path]
             [dieter.asset :as asset]
             [dieter.settings :as settings]))
 
-(defn foreach-file
-  "Iterate through the assets directory"
-  [dir f]
-  (fs/walk
-   dir
-   (fn [root _ files]
-     (doseq [filename files]
-       (f (->> filename
-               (fs/join root)))))))
+(defn relative-path [root file]
+  (let [absroot (.getCanonicalPath (io/file root))
+        absfile (.getCanonicalPath (io/file file))
+        root-length (count absroot)]
+    (.substring absfile (inc root-length))))
 
 (defn load-precompiled-assets
   "Load any assets already in the cache directory"
   []
-  (foreach-file
-   (settings/cache-root)
-   (fn [cached]
-     (let [cached (->> cached
-                       (path/relative-path (settings/cache-root))
-                       (str "/"))
-           uncached (->> cached
-                         (path/uncachify-path))]
-       (cache/add-cached-uri uncached cached)))))
+  (->> (settings/cache-root)
+       file-seq
+       flatten
+       (remove #(.isDirectory %))
+       (map (fn [cached]
+              (let [cached (->> cached
+                                (relative-path (settings/cache-root))
+                                (str "/"))
+                    uncached (->> cached
+                                  (path/uncachify-path))]
+                (cache/add-cached-uri uncached cached))))
+       dorun))
 
 (defn find-and-cache-asset [& args]
   (apply (ns-resolve 'dieter.core 'find-and-cache-asset) args))
 
+(defn delete-dir [directory]
+  (->> directory
+       io/file
+       file-seq
+       flatten
+       (remove #(= directory (.getPath %1)))
+       reverse
+       (map #(.delete %1))
+       dorun
+   ))
+
 (defn precompile [options]
   (settings/with-options options
-    (-> (settings/cache-root) (fs/join "assets") fs/deltree)
+    (-> (settings/cache-root) (str "assets") delete-dir)
     (if (settings/precompiles)
       (doseq [filename (settings/precompiles)]
         (->> filename
              (find-and-cache-asset)))
       (doseq [asset-root (settings/asset-roots)]
-        (foreach-file
-         (fs/join asset-root "assets")
-         (fn [filename]
-           (try (->> filename
-                     (path/relative-path asset-root)
+        (->>
+         (io/file asset-root "assets")         
+         file-seq 
+         flatten         
+         (remove #(.isDirectory %))
+         (map (fn [filename]
+                (try (->> filename
+                     (relative-path asset-root)
                      (str "./")
                      (find-and-cache-asset))
                 (print ".")
                 (catch Exception e
-                  (println "Not built" filename)))))
-        nil))))
+                  (println "Not built" filename)))
+           
+           ))
+         dorun)))))

--- a/dieter-core/src/dieter/v8.clj
+++ b/dieter-core/src/dieter/v8.clj
@@ -1,14 +1,13 @@
 (ns dieter.v8
   (:require [v8.core :as v8]
             [clojure.java.io :as io]
-            [fs]
             [clojure.string :as str]
             [dieter.settings :as settings]))
 
 (defn load-vendor [files]
   (apply str (map (fn [f]
                     (->> f
-                         (fs/join "vendor")
+                         (str "vendor/")
                          io/resource
                          io/reader
                          line-seq

--- a/dieter-core/test/dieter/test/asset/coffeescript.clj
+++ b/dieter-core/test/dieter/test/asset/coffeescript.clj
@@ -6,6 +6,8 @@
 
 (deftest test-preprocess-coffeescript
   (h/with-both-engines
+   (testing "we have a chance to succeed"
+     (is (.exists (io/file "test/fixtures/assets/javascripts/test.js.coffee"))))
     (testing "basic coffee file"
       (is (= "(function() {\n\n  (function(param) {\n    return alert(\"x\");\n  });\n\n}).call(this);\n"
              (cs/preprocess-coffeescript


### PR DESCRIPTION
I started by upgrading libraries for better compatibility with other libs. Ended up upgrading ring, reducing ring dependency to ring-core, and all together removing fs. The fs library is in a bit of flux right now: changing core namespace, removing functionality.  

With what dieter was using it was pretty straightforward just to use Java File + core/io
