### PR TITLE
Support execution on Windows, or when v8 libraries can not be loaded

### DIFF
--- a/dieter-core/src/dieter/v8.clj
+++ b/dieter-core/src/dieter/v8.clj
@@ -1,6 +1,5 @@
 (ns dieter.v8
-  (:require [v8.core :as v8]
-            [clojure.java.io :as io]
+  (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [dieter.settings :as settings]))
 
@@ -28,9 +27,32 @@
 
 (def ^:dynamic context nil)
 
+;; Working around namespaces that fail to load is tricky; after much experimentation, this seems to be the best
+;; approach: creating placeholds then overwriting them if the v8.core namespace actually loads.
+
+(defn- fail [& _]
+  (throw (IllegalStateException. "Use of v8 requires Mac OS X or Linux, plus special setup for the native v8 libraries.")))
+
+(def v8-run-script-in-context fail)
+(def v8-create-context fail)
+
+(try
+  ;; Trying to use a namespace alias, via :as, has just not worked, even when the catch block is triggered.
+  (require 'v8.core)
+
+  (def ^:private v8ns  (-> 'v8.core create-ns ns-map))
+  
+  ;; Redefine in terms of the actual functions. The Clojure compiler gets confused if we reference an aliased
+  ;; namespace that didn't load so we get the namespace's map and extract the desired values directly.
+  (def v8-run-script-in-context ('run-script-in-context v8ns))
+  (def v8-create-context ('create-context v8ns))
+
+  (catch Throwable e
+    (.println (System/err) (str "Unable to load v8.core: " (.getMessage e) " (you may ignore if not using v8)"))))
+
 (defn create-context [preloads]
-  (let [cx (v8/create-context)]
-    (v8/run-script-in-context cx (load-vendor preloads))
+  (let [cx (v8-create-context)]
+    (v8-run-script-in-context cx (load-vendor preloads))
     cx))
 
 (defmacro with-scope [pool preloads & body]
@@ -41,4 +63,4 @@
 
 (defn call [fn-name args]
   (let [script (construct-call fn-name args)]
-    (v8/run-script-in-context context script)))
+    (v8-run-script-in-context context script)))


### PR DESCRIPTION
Previously, dieter could not run on Windows even when the :rhino engine was
selected, because the v8.core namespace failed to load. This change to
dieter.v8 makes it capable of handling that situation, which allows dieter to
run on Windows as well as Mac OS X and Linux. It also allows execution, using
:rhino, when the v8wrapper library is not available.

The code reflects a significant amount of experimentation to make it stable,
since ultimately, the Clojure compiler is being second-guessed and
circumvented.
