### PR TITLE
[0.4.0] Mime type application/octet-stream returned for .dieter manifest in dev mode

### DIFF
--- a/dieter-core/project.clj
+++ b/dieter-core/project.clj
@@ -11,4 +11,5 @@
                  [clj-v8-native "0.1.4"]
                  [org.mozilla/rhino "1.7R4"]
                  [org.clojure/clojure "1.4.0"]]
-  :dev-dependencies [[org.clojure/clojure "1.4.0"]])
+  :dev-dependencies [[org.clojure/clojure "1.4.0"]]
+  :profiles {:dev {:dependencies [[ring-mock "0.1.4"]]}})

--- a/dieter-core/src/dieter/core.clj
+++ b/dieter-core/src/dieter/core.clj
@@ -71,8 +71,7 @@
           (wrap-file (settings/cache-root))
           (asset-builder options)
           (wrap-file-info known-mime-types)
-          (wrap-dieter-mime-types)
-          (wrap-file-info known-mime-types)))))
+          (wrap-dieter-mime-types)))))
 
 
 (defn link-to-asset [adrf & [options]]


### PR DESCRIPTION
First off, thank you for sharing dieter! I am new to clojure, and for my first compojure project I have been trying to integrate dieter 0.4.0. I have a `site.css.dieter` file that always returns mime-type `application/octet-stream` in development mode. But, it works correctly in production mode, returning `text/css`. 

I noticed an extra [`wrap-file-info`](https://github.com/edgecase/dieter/blob/master/dieter-core/src/dieter/core.clj#L75) that may have been introduced in a bad merge commit? 
https://github.com/edgecase/dieter/commit/b018f86fb0ff09f2fc99b9c1949a6ff736695ef1

Hope this helps!
