### PR TITLE
Updated README for dieter-precompile

### DIFF
--- a/lein-dieter-precompile/README.md
+++ b/lein-dieter-precompile/README.md
@@ -4,10 +4,10 @@ A leiningen plugin for precompiling assets using Dieter, similar to Rails' `rake
 
 ## Installation
 
-In `:dev-dependencies`, add:
+In `:plugins`, add:
 
 ```clojure
-[lein-dieter-precompile "0.1"]
+[lein-dieter-precompile "0.2.0"]
 ```
 
 ## Usage


### PR DESCRIPTION
To get this to work (at least with Leiningen 2.2.0), I had to add it to `:plugins`, not `:dev-dependencies`.
