### PR TITLE
fixes precompile

### DIFF
--- a/dieter-core/src/dieter/precompile.clj
+++ b/dieter-core/src/dieter/precompile.clj
@@ -56,7 +56,7 @@
          (remove #(.isDirectory %))
          (map (fn [filename]
                 (try (->> filename
-                     (relative-path asset-root)
+                     (relative-path (str asset-root "/assets"))
                      (str "./")
                      (find-and-cache-asset))
                 (print ".")


### PR DESCRIPTION
The relative paths which were build by precompile/precompile started with  "./asset/" but this is added during the search as well.
