### PR TITLE
alter :path-info as well as :uri

### DIFF
--- a/dieter-core/src/dieter/core.clj
+++ b/dieter-core/src/dieter/core.clj
@@ -39,7 +39,7 @@
                                        find-and-cache-asset)]
             (let [new-uri (path/make-relative-to-cache cached-filename)]
               (cache/add-cached-uri uri new-uri)
-              (app (assoc req :uri new-uri)))
+              (app (assoc req :uri new-uri :path-info new-uri)))
             (app req))
           (app req))))))
 

--- a/dieter-core/src/dieter/jsengine.clj
+++ b/dieter-core/src/dieter/jsengine.clj
@@ -1,8 +1,7 @@
 (ns dieter.jsengine
   (:require [dieter.settings :as settings]
             [dieter.pools :as pools]
-            [dieter.rhino :as rhino]
-            [dieter.v8 :as v8]))
+            [dieter.rhino :as rhino]))
 
 
 ;; TODO: take an asset to avoid slurping here
@@ -16,8 +15,12 @@
               (= engine :rhino))
         (rhino/with-scope pool preloads
           (rhino/call fn-name args))
-        (v8/with-scope pool preloads
-          (v8/call fn-name args))))
+        (do
+          (require 'v8.core) ;v8 is not always available, load it at the last possible moment
+          (let [ws   (ns-resolve 'v8.core :with-scope)
+                call (ns-resolve 'v8.core :call)]
+            (ws pool preloads
+              (call fn-name args))))))
     (catch Exception e
       (let [ste (StackTraceElement. "jsengine"
                                     "compileHamlCoffee" (.getPath file) -1)

--- a/dieter-core/test/dieter/test/core.clj
+++ b/dieter-core/test/dieter/test/core.clj
@@ -57,8 +57,12 @@
 (deftest test-asset-builder
   (settings/with-options {:asset-root "test/fixtures"
                           :cache-root "test/fixtures/asset-cache"}
-    (let [app (fn [req] (:uri req))
+    (let [app (fn [req] (or (:path-info req) (:uri req))) ; see file-request and path-info in ring
           builder (core/asset-builder app)]
+      (testing "plain path, with a server that supplies :path-info (for example: immutant)"
+        (reset! cache/cached-uris {})
+          (is (= "/assets/javascripts/app-0dbd0f18020cf56c28846c40b56b5baa.js"
+               (builder {:path-info "/assets/javascripts/app.js" :uri "/assets/javascripts/app.js"}))))
       (testing "plain file paths"
         (reset! cache/cached-uris {})
         (is (= "/assets/javascripts/app-0dbd0f18020cf56c28846c40b56b5baa.js"


### PR DESCRIPTION
Hey all!

I'm just spinning up a new compojure app and dieter seems like the right lib for me to handle less compilation. However, I noticed that when deploying to immutant dieter wasn't playing nice. So after lots of digging I discovered that the :path-info key in a request is actually preferred over :uri by ring when serving static content. So I wrote a quick patch.

As an aside, issue #48 has also been a problem for me. If you guys are accepting contributions I might be tempted to try a fix for that as well. 

I threw some more detail in the commit message, see below.

When changing the path of a request, be sure to change :path-info as
well as :uri.

Ring actually looks at :path-info _first_. See
https://github.com/ring-clojure/ring/blob/1.2/ring-core/src/ring/middleware/file.clj#L21
and
https://github.com/ring-clojure/ring/blob/1.2/ring-core/src/ring/util/request.clj#L32-L36

So, when we're running on a server that supplies :path-info, we have to
be sure it is correct, or else we'll end up either 404'ing (bad) or
serving the unaltered content (possibly worse).
