### PR TITLE
alter :path-info as well as :uri

### DIFF
--- a/dieter-core/src/dieter/core.clj
+++ b/dieter-core/src/dieter/core.clj
@@ -39,7 +39,7 @@
                                        find-and-cache-asset)]
             (let [new-uri (path/make-relative-to-cache cached-filename)]
               (cache/add-cached-uri uri new-uri)
-              (app (assoc req :uri new-uri)))
+              (app (assoc req :uri new-uri :path-info new-uri)))
             (app req))
           (app req))))))
 

--- a/dieter-core/test/dieter/test/core.clj
+++ b/dieter-core/test/dieter/test/core.clj
@@ -57,8 +57,12 @@
 (deftest test-asset-builder
   (settings/with-options {:asset-root "test/fixtures"
                           :cache-root "test/fixtures/asset-cache"}
-    (let [app (fn [req] (:uri req))
+    (let [app (fn [req] (or (:path-info req) (:uri req))) ; see file-request and path-info in ring
           builder (core/asset-builder app)]
+      (testing "plain path, with a server that supplies :path-info (for example: immutant)"
+        (reset! cache/cached-uris {})
+          (is (= "/assets/javascripts/app-0dbd0f18020cf56c28846c40b56b5baa.js"
+               (builder {:path-info "/assets/javascripts/app.js" :uri "/assets/javascripts/app.js"}))))
       (testing "plain file paths"
         (reset! cache/cached-uris {})
         (is (= "/assets/javascripts/app-0dbd0f18020cf56c28846c40b56b5baa.js"


### PR DESCRIPTION
Hey,

So this used to be pull request #59, but somehow that says it was merged, but it never was.

So here's a new pull request :)

When changing the path of a request, be sure to change :path-info as
well as :uri.

Ring actually looks at :path-info _first_. See
https://github.com/ring-clojure/ring/blob/1.2/ring-core/src/ring/middleware/file.clj#L21
and
https://github.com/ring-clojure/ring/blob/1.2/ring-core/src/ring/util/request.clj#L32-L36

So, when we're running on a server that supplies :path-info, we have to
be sure it is correct, or else we'll end up either 404'ing (bad) or
serving the unaltered content (possibly worse).
